### PR TITLE
Add option to run even after aborted jobs

### DIFF
--- a/src/main/resources/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScript/global.jelly
+++ b/src/main/resources/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScript/global.jelly
@@ -8,6 +8,7 @@
                 <f:option value="SUCCESS" selected="${'SUCCESS' == instance.runCondition}">Only if build is stable</f:option>
                 <f:option value="UNSTABLE" selected="${'UNSTABLE' == instance.runCondition}">Even if the build is unstable</f:option>
                 <f:option value="FAILURE" selected="${'FAILURE' == instance.runCondition}">Even if the build fails</f:option>
+                <f:option value="ABORTED" selected="${'ABORTED' == instance.runCondition}">Always run, even if the job was aborted</f:option>
             </select>
         </f:entry>
     </f:section>


### PR DESCRIPTION
For some uses cases, such as detecting disconnected slaves, it is
important to be able to configure the global post script to run in
conditions worse than build failure including when the job was
aborted.

I have a global post script that looks at the failure history of a job and based on various criteria, disables the node and requeues the job. This simple change makes it possible for this to work even if the job fails because the connection between the slave and the master was lost. I hope you will consider it.