### PR TITLE
Adding support for pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
   <artifactId>global-post-script</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Global+Post+Script+Plugin</url>
@@ -18,7 +18,7 @@
     <url>https://github.com/jenkinsci/global-post-script-plugin/</url>
     <connection>scm:git:git@github.com:jenkinsci/global-post-script-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/global-post-script-plugin.git</developerConnection>
-    <tag>global-post-script-1.1.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,14 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.565.3</version>
-  </parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.565.3</version>
+        <relativePath />
+    </parent>
   <artifactId>global-post-script</artifactId>
-  <version>1.1.4-SNAPSHOT</version>
+  <version>1.1.3</version>
   <packaging>hpi</packaging>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Global+Post+Script+Plugin</url>
@@ -16,7 +18,7 @@
     <url>https://github.com/jenkinsci/global-post-script-plugin/</url>
     <connection>scm:git:git@github.com:jenkinsci/global-post-script-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/global-post-script-plugin.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>global-post-script-1.1.3</tag>
   </scm>
 
   <properties>

--- a/src/main/java/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScript.java
+++ b/src/main/java/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScript.java
@@ -48,11 +48,6 @@ public class GlobalPostScript extends RunListener<Run<?, ?>> implements Describa
   public void onCompleted(Run run, TaskListener listener) {
     EnvVars envVars = getEnvVars(run, listener);
 
-    // This method also get executed for each sub-module in multi-module Maven project.
-    if (null == envVars || !envVars.containsKey("EXECUTOR_NUMBER")) {
-      return;
-    }
-
     if (run.getResult().isWorseThan(getDescriptorImpl().getResultCondition())) {
       return;
     }


### PR DESCRIPTION
This removes a conditional block that was preventing global-post-script-plugin from running on pipeline jobs.

"// This method also get executed for each sub-module in multi-module Maven project."
I am unable to test any impact on multi-module Maven projects, but it seems likely that Maven plugin may no longer have the limitation mentioned in the comment.